### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Add the dependency
 
 ```groovy
 dependencies {
+	//PermissionsDispatcher has to be above AndroidAnnotations
     compile 'com.github.hotchemi:permissionsdispatcher:2.1.3'
     apt 'com.github.hotchemi:permissionsdispatcher-processor:2.1.3'
     compile 'org.androidannotations:androidannotations-api:4.0.0'
@@ -30,7 +31,7 @@ dependencies {
 }
 ```
 
-**Please notice that PermissionsDispatcher is above AndroidAnnotations.**
+> #Please notice that PermissionsDispatcher is above AndroidAnnotations.
 
 ## License
 


### PR DESCRIPTION
Emphasis the fact that PermissionsDispatcher has to be above AndroidAnnotations in dependencies declaration.

I think just bold is not enough, as I just lost 1 hour wondering why nothing gets generated.